### PR TITLE
Removed strong tag in faulty nested header tag

### DIFF
--- a/Resources/Private/Templates/Comment/List.html
+++ b/Resources/Private/Templates/Comment/List.html
@@ -49,7 +49,7 @@
                         </div>
                     </f:then>
                     <f:else>
-                        <h5><strong><f:translate key='tx_nsnewscomments_domain_model_comment.nocommentsfound'/></h5></strong>
+                        <h5><f:translate key='tx_nsnewscomments_domain_model_comment.nocommentsfound'/></h5>
                     </f:else>
                 </f:if>
                 <ul class="comments-list" id="comments-list">


### PR DESCRIPTION
The tags for "h5" and "strong" where nested incorrectly. 
Also ist "strong" not necessary here.